### PR TITLE
Introducing `preserve` option

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,9 +19,18 @@ function compose (first, second, third) {
   return first
 }
 
+function updateValue (declaration, value, preserve) {
+  if (preserve) {
+    declaration.cloneBefore({ value })
+  } else {
+    declaration.value = value
+  }
+}
+
 module.exports = opts => {
   opts = opts || {}
   let precalculate = opts.precalculate ? Boolean(opts.precalculate) : false
+  let preserve = opts.preserve ? Boolean(opts.preserve) : false
 
   return {
     postcssPlugin: 'postcss-clamp',
@@ -51,37 +60,61 @@ module.exports = opts => {
           second.type !== 'word' ||
           third.type !== 'word'
         ) {
-          decl.value = naive
+          updateValue(
+            decl,
+            naive,
+            preserve
+          )
           return
         }
         let parsedSecond = parseValue(second.value)
         let parsedThird = parseValue(third.value)
         if (parsedSecond === undefined || parsedThird === undefined) {
-          decl.value = naive
+          updateValue(
+            decl,
+            naive,
+            preserve
+          )
           return
         }
         let [secondValue, secondUnit] = parsedSecond
         let [thirdValue, thirdUnit] = parsedThird
         if (secondUnit !== thirdUnit) {
-          decl.value = naive
+          updateValue(
+            decl,
+            naive,
+            preserve
+          )
           return
         }
         let parsedFirst = parseValue(first.value)
         if (parsedFirst === undefined) {
           let secondThirdValue =
             `${ secondValue + thirdValue }${ secondUnit }`
-          decl.value = compose(valueParser.stringify(first), secondThirdValue)
+          updateValue(
+            decl,
+            compose(valueParser.stringify(first), secondThirdValue),
+            preserve
+          )
           return
         }
         let [firstValue, firstUnit] = parsedFirst
         if (firstUnit !== secondUnit) {
           let secondThirdValue =
             `${ secondValue + thirdValue }${ secondUnit }`
-          decl.value = compose(valueParser.stringify(first), secondThirdValue)
+          updateValue(
+            decl,
+            compose(valueParser.stringify(first), secondThirdValue),
+            preserve
+          )
           return
         }
-        decl.value =
-          compose(`${ firstValue + secondValue + thirdValue }${ secondUnit }`)
+
+        updateValue(
+          decl,
+          compose(`${ firstValue + secondValue + thirdValue }${ secondUnit }`),
+          preserve
+        )
       })
     }
   }

--- a/index.test.js
+++ b/index.test.js
@@ -17,6 +17,14 @@ it('handle simple transformation (only values)', async () => {
   )
 })
 
+it('handle simple transformation (only values) with preserve', async () => {
+  await run(
+    'a{ width: clamp(10px, 64px, 80px); }',
+    'a{ width: max(10px, min(64px, 80px)); width: clamp(10px, 64px, 80px); }',
+    { preserve: true }
+  )
+})
+
 it('handle transformation with functions', async () => {
   await run(
     'a{ width: clamp(calc(100% - 10px), min(10px, 100%), max(40px, 4em)); }',
@@ -24,10 +32,27 @@ it('handle transformation with functions', async () => {
   )
 })
 
+it('handle transformation with functions with preserve', async () => {
+  await run(
+    'a{ width: clamp(calc(100% - 10px), min(10px, 100%), max(40px, 4em)); }',
+    'a{ width: max(calc(100% - 10px), min(min(10px, 100%), max(40px, 4em))); ' +
+    'width: clamp(calc(100% - 10px), min(10px, 100%), max(40px, 4em)); }',
+    { preserve: true }
+  )
+})
+
 it('handle transformation with different units', async () => {
   await run(
     'a{ width: clamp(10%, 2px, 4rem); }',
     'a{ width: max(10%, min(2px, 4rem)); }'
+  )
+})
+
+it('handle transformation with different units and preserve', async () => {
+  await run(
+    'a{ width: clamp(10%, 2px, 4rem); }',
+    'a{ width: max(10%, min(2px, 4rem)); width: clamp(10%, 2px, 4rem); }',
+    { preserve: true }
   )
 })
 
@@ -71,6 +96,15 @@ it('precalculate second and third with the same unit (float and int values)',
       'a{ width: clamp(10%, 2.5px, 5px); }',
       'a{ width: max(10%, 7.5px); }',
       { precalculate: true }
+    )
+  })
+
+it('precalculate 2nd & 3rd with the same unit (float and int vals) & preserve',
+  async () => {
+    await run(
+      'a{ width: clamp(10%, 2.5px, 5px); }',
+      'a{ width: max(10%, 7.5px); width: clamp(10%, 2.5px, 5px); }',
+      { precalculate: true, preserve: true }
     )
   })
 
@@ -139,10 +173,26 @@ it('handle not valid values', async () => {
   )
 })
 
+it('handle not valid values with preserve', async () => {
+  await run(
+    'a{ width: clamp(a, b, c); }',
+    'a{ width: max(a, min(b, c)); width: clamp(a, b, c); }',
+    { precalculate: true, preserve: true }
+  )
+})
+
 it('handle not valid values mixed with valid', async () => {
   await run(
     'a{ width: clamp(a, 1px, 2em); }',
     'a{ width: max(a, min(1px, 2em)); }',
     { precalculate: true }
+  )
+})
+
+it('handle not valid values mixed with valid and preserve', async () => {
+  await run(
+    'a{ width: clamp(a, 1px, 2em); }',
+    'a{ width: max(a, min(1px, 2em)); width: clamp(a, 1px, 2em); }',
+    { precalculate: true, preserve: true }
   )
 })

--- a/index.test.js
+++ b/index.test.js
@@ -31,7 +31,7 @@ it('handle transformation with different units', async () => {
   )
 })
 
-it('transform only function with 3 paramters', async () => {
+it('transform only function with 3 parameters', async () => {
   await run(
     'a{ width: clamp(10%, 2px, 4rem);' +
     '\nheight: clamp(10px, 20px, 30px, 40px); }',
@@ -99,7 +99,7 @@ it('precalculate all values with the same unit (int and float values)',
     )
   })
 
-it('handle function with enalbe precalculation as third', async () => {
+it('handle function with enable precalculation as third', async () => {
   await run(
     'a{ width: clamp(10px, 2px, calc(10px + 100%)); }',
     'a{ width: max(10px, min(2px, calc(10px + 100%))); }',
@@ -107,7 +107,7 @@ it('handle function with enalbe precalculation as third', async () => {
   )
 })
 
-it('handle function with enalbe precalculation as second', async () => {
+it('handle function with enable precalculation as second', async () => {
   await run(
     'a{ width: clamp(10px, calc(10px + 100%), 2px); }',
     'a{ width: max(10px, min(calc(10px + 100%), 2px)); }',
@@ -115,7 +115,7 @@ it('handle function with enalbe precalculation as second', async () => {
   )
 })
 
-it('handle function with enalbe precalculation as first', async () => {
+it('handle function with enable precalculation as first', async () => {
   await run(
     'a{ width: clamp(calc(10px + 100%), 10px, 2px); }',
     'a{ width: max(calc(10px + 100%), 12px); }',
@@ -123,7 +123,7 @@ it('handle function with enalbe precalculation as first', async () => {
   )
 })
 
-it('handle function with enalbe precalculation as all', async () => {
+it('handle function with enable precalculation as all', async () => {
   await run(
     'a{ width: clamp(calc(10px + 100%), calc(10rem + 200%), 10px); }',
     'a{ width: max(calc(10px + 100%), min(calc(10rem + 200%), 10px)); }',


### PR DESCRIPTION
As agreed on #11, here's a PR that introduces `preserve` as an option!

You might want to look into peer resolving and upgrading all of the dependencies since newer node versions lead to issues with `peerDependencies` when installing such as:

```bash
➜  postcss-clamp git:(master) ✗ npm i
npm ERR! code ERESOLVE
npm ERR! ERESOLVE unable to resolve dependency tree
npm ERR!
npm ERR! While resolving: postcss-clamp@2.0.0
npm ERR! Found: eslint@7.0.0
npm ERR! node_modules/eslint
npm ERR!   dev eslint@"^7.0.0" from the root project
npm ERR!
npm ERR! Could not resolve dependency:
npm ERR! peer eslint@"^6.8.0" from @logux/eslint-config@36.1.3
npm ERR! node_modules/@logux/eslint-config
npm ERR!   dev @logux/eslint-config@"^36.1.3" from the root project
npm ERR!
npm ERR! Fix the upstream dependency conflict, or retry
npm ERR! this command with --force, or --legacy-peer-deps
npm ERR! to accept an incorrect (and potentially broken) dependency resolution.
npm ERR!
npm ERR! See /Users/alaguna/.npm/eresolve-report.txt for a full report.

npm ERR! A complete log of this run can be found in:
npm ERR!     ~/.npm/_logs/2022-01-05T15_49_02_007Z-debug.log
```

However, this was out of the scope of this change. I haven't added `preserve` to every case since it felt a bit moot but to a few so it's at least representative.

Fixes #11 