### PR TITLE
Fixing bug & updating dependencies

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,10 +10,10 @@ function parseValue (value) {
 
 function compose (first, second, third) {
   if (first && second && third) {
-    return `max(${ first }, min(${ second }, ${ third }))`
+    return `max(${first}, min(${second}, ${third}))`
   }
   if (first && second) {
-    return `max(${ first }, ${ second })`
+    return `max(${first}, ${second})`
   }
 
   return first
@@ -42,8 +42,8 @@ module.exports = opts => {
         let nodes = node.nodes
         if (
           node.type !== 'function' ||
-            node.value !== 'clamp' ||
-            nodes.length !== 5
+          node.value !== 'clamp' ||
+          nodes.length !== 5
         ) {
           return
         }
@@ -55,42 +55,25 @@ module.exports = opts => {
           valueParser.stringify(second),
           valueParser.stringify(third)
         )
-        if (
-          !precalculate ||
-          second.type !== 'word' ||
-          third.type !== 'word'
-        ) {
-          updateValue(
-            decl,
-            naive,
-            preserve
-          )
+        if (!precalculate || second.type !== 'word' || third.type !== 'word') {
+          updateValue(decl, naive, preserve)
           return
         }
         let parsedSecond = parseValue(second.value)
         let parsedThird = parseValue(third.value)
         if (parsedSecond === undefined || parsedThird === undefined) {
-          updateValue(
-            decl,
-            naive,
-            preserve
-          )
+          updateValue(decl, naive, preserve)
           return
         }
         let [secondValue, secondUnit] = parsedSecond
         let [thirdValue, thirdUnit] = parsedThird
         if (secondUnit !== thirdUnit) {
-          updateValue(
-            decl,
-            naive,
-            preserve
-          )
+          updateValue(decl, naive, preserve)
           return
         }
         let parsedFirst = parseValue(first.value)
         if (parsedFirst === undefined) {
-          let secondThirdValue =
-            `${ secondValue + thirdValue }${ secondUnit }`
+          let secondThirdValue = `${secondValue + thirdValue}${secondUnit}`
           updateValue(
             decl,
             compose(valueParser.stringify(first), secondThirdValue),
@@ -100,8 +83,7 @@ module.exports = opts => {
         }
         let [firstValue, firstUnit] = parsedFirst
         if (firstUnit !== secondUnit) {
-          let secondThirdValue =
-            `${ secondValue + thirdValue }${ secondUnit }`
+          let secondThirdValue = `${secondValue + thirdValue}${secondUnit}`
           updateValue(
             decl,
             compose(valueParser.stringify(first), secondThirdValue),
@@ -112,7 +94,7 @@ module.exports = opts => {
 
         updateValue(
           decl,
-          compose(`${ firstValue + secondValue + thirdValue }${ secondUnit }`),
+          compose(`${firstValue + secondValue + thirdValue}${secondUnit}`),
           preserve
         )
       })

--- a/index.js
+++ b/index.js
@@ -20,10 +20,29 @@ function compose (first, second, third) {
 }
 
 function updateValue (declaration, value, preserve) {
+  let newValue = value
+  let newValueAst = valueParser(value)
+  let valueAST = valueParser(declaration.value)
+
+  // Means clamp is not alone within the declaration
+  if (valueAST.nodes.length > 1) {
+    let clampIndex = valueAST.nodes.findIndex(
+      node => node.type === 'function' && node.value === 'clamp'
+    )
+
+    valueAST.nodes = [
+      ...valueAST.nodes.slice(0, clampIndex),
+      ...newValueAst.nodes,
+      ...valueAST.nodes.slice(clampIndex + 1)
+    ]
+
+    newValue = valueAST.toString()
+  }
+
   if (preserve) {
-    declaration.cloneBefore({ value })
+    declaration.cloneBefore({ value: newValue })
   } else {
-    declaration.value = value
+    declaration.value = newValue
   }
 }
 

--- a/index.test.js
+++ b/index.test.js
@@ -184,3 +184,17 @@ it('handle not valid values mixed with valid and preserve', async () => {
     { precalculate: true, preserve: true }
   )
 })
+
+it('handle complex values', async () => {
+  await run(
+    'a{ grid-template-columns: clamp(22rem, 40%, 32rem) minmax(0, 1fr); }',
+    'a{ grid-template-columns: max(22rem, min(40%, 32rem)) minmax(0, 1fr); }'
+  )
+})
+
+it('handle multiple complex values', async () => {
+  await run(
+    'a{ margin: clamp(1rem, 2%, 3rem) 4px clamp(5rem, 6%, 7rem) 8rem; }',
+    'a{ margin: max(1rem, min(2%, 3rem)) 4px max(5rem, min(6%, 7rem)) 8rem; }'
+  )
+})

--- a/index.test.js
+++ b/index.test.js
@@ -3,8 +3,9 @@ let postcss = require('postcss')
 let clamp = require('./')
 
 async function run (input, output, opts) {
-  let result = await postcss([clamp(opts)])
-    .process(input, { from: '/test.css' })
+  let result = await postcss([clamp(opts)]).process(input, {
+    from: '/test.css'
+  })
   expect(result.css).toEqual(output)
   expect(result.warnings()).toHaveLength(0)
   return result
@@ -36,7 +37,7 @@ it('handle transformation with functions with preserve', async () => {
   await run(
     'a{ width: clamp(calc(100% - 10px), min(10px, 100%), max(40px, 4em)); }',
     'a{ width: max(calc(100% - 10px), min(min(10px, 100%), max(40px, 4em))); ' +
-    'width: clamp(calc(100% - 10px), min(10px, 100%), max(40px, 4em)); }',
+      'width: clamp(calc(100% - 10px), min(10px, 100%), max(40px, 4em)); }',
     { preserve: true }
   )
 })
@@ -59,9 +60,9 @@ it('handle transformation with different units and preserve', async () => {
 it('transform only function with 3 parameters', async () => {
   await run(
     'a{ width: clamp(10%, 2px, 4rem);' +
-    '\nheight: clamp(10px, 20px, 30px, 40px); }',
+      '\nheight: clamp(10px, 20px, 30px, 40px); }',
     'a{ width: max(10%, min(2px, 4rem));' +
-    '\nheight: clamp(10px, 20px, 30px, 40px); }'
+      '\nheight: clamp(10px, 20px, 30px, 40px); }'
   )
 })
 
@@ -72,48 +73,40 @@ it('transform only clamp function', async () => {
   )
 })
 
-it('precalculate second and third with the same unit (int values)',
-  async () => {
-    await run(
-      'a{ width: clamp(10%, 2px, 5px); }',
-      'a{ width: max(10%, 7px); }',
-      { precalculate: true }
-    )
+it('precalculate second and third with the same unit (int values)', async () => {
+  await run('a{ width: clamp(10%, 2px, 5px); }', 'a{ width: max(10%, 7px); }', {
+    precalculate: true
   })
+})
 
-it('precalculate second and third with the same unit (float values)',
-  async () => {
-    await run(
-      'a{ width: clamp(10%, 2.5px, 5.1px); }',
-      'a{ width: max(10%, 7.6px); }',
-      { precalculate: true }
-    )
-  })
-
-it('precalculate second and third with the same unit (float and int values)',
-  async () => {
-    await run(
-      'a{ width: clamp(10%, 2.5px, 5px); }',
-      'a{ width: max(10%, 7.5px); }',
-      { precalculate: true }
-    )
-  })
-
-it('precalculate 2nd & 3rd with the same unit (float and int vals) & preserve',
-  async () => {
-    await run(
-      'a{ width: clamp(10%, 2.5px, 5px); }',
-      'a{ width: max(10%, 7.5px); width: clamp(10%, 2.5px, 5px); }',
-      { precalculate: true, preserve: true }
-    )
-  })
-
-it('precalculate all values with the same unit (int values)', async () => {
+it('precalculate second and third with the same unit (float values)', async () => {
   await run(
-    'a{ width: clamp(10px, 2px, 5px); }',
-    'a{ width: 17px; }',
+    'a{ width: clamp(10%, 2.5px, 5.1px); }',
+    'a{ width: max(10%, 7.6px); }',
     { precalculate: true }
   )
+})
+
+it('precalculate second and third with the same unit (float and int values)', async () => {
+  await run(
+    'a{ width: clamp(10%, 2.5px, 5px); }',
+    'a{ width: max(10%, 7.5px); }',
+    { precalculate: true }
+  )
+})
+
+it('precalculate 2nd & 3rd with the same unit (float and int vals) & preserve', async () => {
+  await run(
+    'a{ width: clamp(10%, 2.5px, 5px); }',
+    'a{ width: max(10%, 7.5px); width: clamp(10%, 2.5px, 5px); }',
+    { precalculate: true, preserve: true }
+  )
+})
+
+it('precalculate all values with the same unit (int values)', async () => {
+  await run('a{ width: clamp(10px, 2px, 5px); }', 'a{ width: 17px; }', {
+    precalculate: true
+  })
 })
 
 it('precalculate all values with the same unit (float values)', async () => {
@@ -124,14 +117,11 @@ it('precalculate all values with the same unit (float values)', async () => {
   )
 })
 
-it('precalculate all values with the same unit (int and float values)',
-  async () => {
-    await run(
-      'a{ width: clamp(10.4px, 2px, 5.9px); }',
-      'a{ width: 18.3px; }',
-      { precalculate: true }
-    )
+it('precalculate all values with the same unit (int and float values)', async () => {
+  await run('a{ width: clamp(10.4px, 2px, 5.9px); }', 'a{ width: 18.3px; }', {
+    precalculate: true
   })
+})
 
 it('handle function with enable precalculation as third', async () => {
   await run(
@@ -166,11 +156,9 @@ it('handle function with enable precalculation as all', async () => {
 })
 
 it('handle not valid values', async () => {
-  await run(
-    'a{ width: clamp(a, b, c); }',
-    'a{ width: max(a, min(b, c)); }',
-    { precalculate: true }
-  )
+  await run('a{ width: clamp(a, b, c); }', 'a{ width: max(a, min(b, c)); }', {
+    precalculate: true
+  })
 })
 
 it('handle not valid values with preserve', async () => {

--- a/package.json
+++ b/package.json
@@ -15,29 +15,29 @@
   "author": "Ivan Menshykov <ivan.menshykov@gmail.com>",
   "license": "MIT",
   "dependencies": {
-    "postcss-value-parser": "^4.1.0"
+    "postcss-value-parser": "^4.2.0"
   },
   "devDependencies": {
-    "@logux/eslint-config": "^36.1.3",
-    "clean-publish": "^1.1.7",
-    "eslint": "^7.0.0",
+    "@logux/eslint-config": "^44.2.0",
+    "clean-publish": "^4.0.0",
+    "eslint": "^7.32.0",
     "eslint-ci": "^1.0.0",
     "eslint-config-postcss": "^4.0.0",
-    "eslint-config-standard": "^14.1.1",
+    "eslint-config-standard": "^16.0.3",
     "eslint-plugin-es5": "^1.5.0",
-    "eslint-plugin-import": "^2.20.2",
-    "eslint-plugin-jest": "^23.10.0",
+    "eslint-plugin-import": "^2.25.4",
+    "eslint-plugin-jest": "^24.7.0",
     "eslint-plugin-node": "^11.1.0",
-    "eslint-plugin-prefer-let": "^1.0.1",
-    "eslint-plugin-promise": "^4.2.1",
+    "eslint-plugin-prefer-let": "^1.1.0",
+    "eslint-plugin-promise": "^4.3.1",
     "eslint-plugin-security": "^1.4.0",
-    "eslint-plugin-standard": "^4.0.1",
-    "eslint-plugin-unicorn": "^19.0.1",
-    "jest": "^26.0.1",
-    "postcss": "^8.4.5"
+    "eslint-plugin-standard": "^4.1.0",
+    "eslint-plugin-unicorn": "^28.0.2",
+    "jest": "^27.5.1",
+    "postcss": "^8.4.6"
   },
   "peerDependencies": {
-    "postcss": "^8.4.5"
+    "postcss": "^8.4.6"
   },
   "scripts": {
     "test": "jest && eslint-ci *.js"


### PR DESCRIPTION
Hi @polemius !

The plugin was doing a very optimistic replacement which basically discarded anything else that was on the rule. This was discarding information on rules such as `grid-template-columns` but also failing on more complex values such as a composed margin.  For more context see https://github.com/csstools/postcss-plugins/issues/260

I've also upgraded dependencies as much as possible and re-linted the files. Upgrading any more causes dependencies to not be meetable as `peerDependencies` don't match.  

Can't upgrade `yarn.lock` since I don't have `yarn` installed.